### PR TITLE
little fix which fix the agent from crashing

### DIFF
--- a/memcached/memcached
+++ b/memcached/memcached
@@ -9,8 +9,11 @@
 #
 # 2013-11-28 Stephan Helas
 #       - Patch to exit correctly
+#
+# 2017-01-30 Nokius
+#       - print output to /dev/null and remove wrong lines from agent
 
-if which nc && which memcached; then
+if which nc > /dev/null && which memcached > /dev/null ; then
     echo '<<<memcached>>>'
     echo "stats" | nc localhost 11211
 fi


### PR DESCRIPTION
The agent had following issue 

~~~~
<<<local>>>
/usr/bin/nc
/usr/bin/memcached
<<<memcached>>>
STAT pid xxx^M
STAT uptime xxxxx^M
~~~~

with the little fix the agent output looks like this

~~~~
<<<local>>>
<<<memcached>>>
STAT pid xxxx^M
STAT uptime xxxxx^M
~~~~
 
now the agent is not crashing / not showing wrong output 